### PR TITLE
Fixing check for the presence of certificatePath parameter in deploy request

### DIFF
--- a/sdk/node/doc/assets/js/.gitignore
+++ b/sdk/node/doc/assets/js/.gitignore
@@ -1,1 +1,0 @@
-modernizr.js

--- a/sdk/node/doc/modules/.gitignore
+++ b/sdk/node/doc/modules/.gitignore
@@ -1,1 +1,0 @@
-_typedoc_special_d_.html

--- a/sdk/node/package.json
+++ b/sdk/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hfc",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "bin": "./bin/main.js",
   "typings": "hfc.d.ts",
   "main": "index.js",

--- a/sdk/node/src/hfc.ts
+++ b/sdk/node/src/hfc.ts
@@ -1265,7 +1265,7 @@ export class TransactionContext extends events.EventEmitter {
      * @param tx {Transaction} The transaction.
      */
     private execute(tx:Transaction):TransactionContext {
-        debug('Executing transaction [%j]', tx);
+        debug('Executing transaction');
 
         let self = this;
         // Get the TCert
@@ -1588,7 +1588,11 @@ export class TransactionContext extends events.EventEmitter {
      	  dockerFileContents = util.format(dockerFileContents, hash);
 
         // Add the certificate path on the server, if it is being passed in
-        if (request.certificatePath != "") {
+        debug("type of request.certificatePath: " + typeof(request.certificatePath));
+        debug("request.certificatePath: " + request.certificatePath);
+        if (request.certificatePath !== "" && request.certificatePath !== undefined) {
+            debug("Adding COPY certificate.pem command");
+
             dockerFileContents = dockerFileContents + "\n" + "COPY certificate.pem %s";
             dockerFileContents = util.format(dockerFileContents, request.certificatePath);
         }


### PR DESCRIPTION
## Description

Adding an additional check for the request.certificatePath parameter in the deploy request. This check will make sure the parameter is not 'undefined', before it was only testing for the parameter being empty string.
## Motivation and Context

This change is necessary as the initial check was performed incorrectly and the additional 'COPY' docker command was being added when it was not supposed to be. That was causing COPY to fail and therefore the deploy was failing as well given that the Docker build fails.
## How Has This Been Tested?

Running through the existing unit tests, focusing on deploy in network mode. 
## Checklist:
- [x] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff).
- [x] I have either added documentation to cover my changes or this change requires no new documentation.
- [x] I have either added unit tests to cover my changes or this change requires no new tests.
- [x] I have run [golint](https://github.com/golang/lint) and have fixed valid warnings in code I have added or modified. This tool generates false positives so you may choose to ignore some warnings. The goal is clean, consistent, and readable code.

Signed-off-by: Anna D Derbakova adderbak@us.ibm.com
